### PR TITLE
feat: remove plan validation argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ You need the following permissions to run this module.
 | <a name="input_members"></a> [members](#input\_members) | Allocated number of members. For more information, see https://cloud.ibm.com/docs/databases-for-elasticsearch?topic=databases-for-elasticsearch-resources-scaling | `number` | `3` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the Elasticsearch instance. | `string` | n/a | yes |
 | <a name="input_plan"></a> [plan](#input\_plan) | The name of the service plan that you choose for your Elasticsearch instance | `string` | `"enterprise"` | no |
-| <a name="input_plan_validation"></a> [plan\_validation](#input\_plan\_validation) | Enable or disable validating the database parameters for elasticsearch during the plan phase | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where you want to deploy your instance. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the Elasticsearch instance will be created. | `string` | n/a | yes |
 | <a name="input_service_credential_names"></a> [service\_credential\_names](#input\_service\_credential\_names) | Map of name, role for service credentials that you want to create for the database | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,6 @@ resource "ibm_database" "elasticsearch" {
   depends_on                = [ibm_iam_authorization_policy.policy]
   name                      = var.name
   plan                      = var.plan
-  plan_validation           = var.plan_validation
   location                  = var.region
   service                   = "databases-for-elasticsearch"
   version                   = var.elasticsearch_version

--- a/variables.tf
+++ b/variables.tf
@@ -24,12 +24,6 @@ variable "tags" {
   default     = []
 }
 
-variable "plan_validation" {
-  type        = bool
-  description = "Enable or disable validating the database parameters for elasticsearch during the plan phase"
-  default     = true
-}
-
 variable "service_endpoints" {
   type        = string
   description = "Sets the endpoint of the instance, valid values are 'public', 'private', or 'public-and-private'"


### PR DESCRIPTION
SKIP UPGRADE TEST: existing variable deleted

### Description

Remove deprecated "plan_validation" argument.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

plan_validation variable has been removed as the underlying provider does not longer support this input (as of version 1.59). Note that the module already performs some level of validations which would cover some of the removed features from the provider, albeit not a 100% equivalent.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
