### PR TITLE
fix: bump IBM provider to 1.62.0 in preperation for CBR update

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.61.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, <2.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.61.0"
+      version = "1.62.0"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.61.0, <2.0.0"
+      version = ">=1.62.0, <2.0.0"
     }
     # The elasticsearch provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     elasticsearch = {

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.62.0"
     }
   }
 }

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -14,7 +14,7 @@ The IBM Cloud Framework for Financial Services mandates the application of an in
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.61.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, <2.0.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -8,7 +8,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Use "greater than or equal to" range in modules
-      version = ">= 1.61.0, <2.0.0"
+      version = ">= 1.62.0, <2.0.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.61.0, <2.0.0"
+      version = ">= 1.62.0, <2.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### Description

Bump IBM provider to 1.62.0 in preparation for a renovate PR to update CBR to a version that requires 1.62.0

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Bump IBM Provider to 1.62.0

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
