### PR TITLE
fix: workaround provider idempotent issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,8 @@ resource "ibm_database" "elasticsearch" {
       # Ignore changes to these because a change will destroy and recreate the instance
       version,
       key_protect_key,
-      backup_encryption_key_crn
+      backup_encryption_key_crn,
+      connectionstrings # https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5546
     ]
   }
 


### PR DESCRIPTION
### Description

Provider 1.68.0 has an idempotent issue with ibm_database.  https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5546

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This works around an idempotent issue in the 1.68.0 provider.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
