### PR TITLE
fix: add count to wait

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "ibm_iam_authorization_policy" "policy" {
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4478
 resource "time_sleep" "wait_for_authorization_policy" {
+  count      = var.kms_encryption_enabled == false || var.skip_iam_authorization_policy ? 0 : 1
   depends_on = [ibm_iam_authorization_policy.policy]
 
   create_duration = "30s"

--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,13 @@ locals {
       can(regex(".*hs-crypto.*", var.kms_key_crn)) ? "hs-crypto" : "unrecognized key type"
     )
   ) : "no key crn"
+
+  create_kp_auth_policy = var.kms_encryption_enabled == false || var.skip_iam_authorization_policy ? 0 : 1
 }
 
 # Create IAM Access Policy to allow Key protect to access Elasticsearch instance
 resource "ibm_iam_authorization_policy" "policy" {
-  count                       = var.kms_encryption_enabled == false || var.skip_iam_authorization_policy ? 0 : 1
+  count                       = local.create_kp_auth_policy
   source_service_name         = "databases-for-elasticsearch"
   source_resource_group_id    = var.resource_group_id
   target_service_name         = local.kms_service
@@ -45,7 +47,7 @@ resource "ibm_iam_authorization_policy" "policy" {
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4478
 resource "time_sleep" "wait_for_authorization_policy" {
-  count      = var.kms_encryption_enabled == false || var.skip_iam_authorization_policy ? 0 : 1
+  count      = local.create_kp_auth_policy
   depends_on = [ibm_iam_authorization_policy.policy]
 
   create_duration = "30s"

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -17,6 +17,7 @@ locals {
   use_existing_db_instance  = var.existing_db_instance_crn != null
 
   create_cross_account_auth_policy = !var.skip_iam_authorization_policy && var.ibmcloud_kms_api_key != null
+  create_sm_auth_policy            = var.skip_es_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
   kms_service_name = local.kms_key_crn != null ? (
     can(regex(".*kms.*", local.kms_key_crn)) ? "kms" : can(regex(".*hs-crypto.*", local.kms_key_crn)) ? "hs-crypto" : null
   ) : null
@@ -132,7 +133,7 @@ resource "random_password" "admin_password" {
 
 # create a service authorization between Secrets Manager and the target service (Elastic Search)
 resource "ibm_iam_authorization_policy" "secrets_manager_key_manager" {
-  count                       = var.skip_es_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
+  count                       = local.create_sm_auth_policy
   depends_on                  = [module.elasticsearch]
   source_service_name         = "secrets-manager"
   source_resource_instance_id = local.existing_secrets_manager_instance_guid
@@ -144,7 +145,7 @@ resource "ibm_iam_authorization_policy" "secrets_manager_key_manager" {
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4478
 resource "time_sleep" "wait_for_es_authorization_policy" {
-  count           = var.skip_es_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
+  count           = local.create_sm_auth_policy
   depends_on      = [ibm_iam_authorization_policy.secrets_manager_key_manager]
   create_duration = "30s"
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -57,6 +57,7 @@ resource "ibm_iam_authorization_policy" "kms_policy" {
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4478
 resource "time_sleep" "wait_for_authorization_policy" {
+  count           = local.create_cross_account_auth_policy ? 1 : 0
   depends_on      = [ibm_iam_authorization_policy.kms_policy]
   create_duration = "30s"
 }
@@ -143,6 +144,7 @@ resource "ibm_iam_authorization_policy" "secrets_manager_key_manager" {
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4478
 resource "time_sleep" "wait_for_es_authorization_policy" {
+  count           = var.skip_es_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
   depends_on      = [ibm_iam_authorization_policy.secrets_manager_key_manager]
   create_duration = "30s"
 }


### PR DESCRIPTION
### Description
If the auth policy creation is skipped, the wait will now also be skipped.
resolves https://github.com/terraform-ibm-modules/terraform-ibm-icd-elasticsearch/issues/283

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
