### PR TITLE
fix: add extra validation for kms

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -21,8 +21,6 @@ locals {
   validate_kms_1 = var.existing_db_instance_crn != null ? true : var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null || var.existing_kms_key_crn != null || var.existing_backup_kms_key_crn != null) ? tobool("When setting values for 'existing_kms_instance_crn', 'existing_kms_key_crn' or 'existing_backup_kms_key_crn', the 'use_ibm_owned_encryption_key' input must be set to false.") : true
   # tflint-ignore: terraform_unused_declarations
   validate_kms_2 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn == null && var.existing_kms_key_crn == null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value is required for either 'existing_kms_instance_crn' (to create a new key), or 'existing_kms_key_crn' to use an existing key.") : true
-  # tflint-ignore: terraform_unused_declarations
-  validate_kms_3 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null && var.existing_kms_key_crn != null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value cannot be passed for both 'existing_kms_instance_crn' (to create a new key), and 'existing_kms_key_crn' (to use an existing key).") : true
 }
 
 #######################################################################################################################
@@ -30,7 +28,7 @@ locals {
 #######################################################################################################################
 
 locals {
-  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null && var.existing_kms_instance_crn != null ? 1 : 0 # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
+  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null ? 1 : 0 # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
   elasticsearch_key_name      = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_name}" : var.elasticsearch_key_name
   elasticsearch_key_ring_name = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_ring_name}" : var.elasticsearch_key_ring_name
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -22,7 +22,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   validate_kms_2 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn == null && var.existing_kms_key_crn == null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value is required for either 'existing_kms_instance_crn' (to create a new key), or 'existing_kms_key_crn' to use an existing key.") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_kms_3 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null && var.existing_kms_key_crn != null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value cannot be passed for both 'existing_kms_instance_crn' (to create a new key), and 'existing_kms_key_crn' to use an existing key.") : true
+  validate_kms_3 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null && var.existing_kms_key_crn != null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value cannot be passed for both 'existing_kms_instance_crn' (to create a new key), and 'existing_kms_key_crn' (to use an existing key).") : true
 }
 
 #######################################################################################################################

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -30,7 +30,7 @@ locals {
 #######################################################################################################################
 
 locals {
-  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null && var.existing_kms_instance_crn != null ? true : false # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
+  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null && var.existing_kms_instance_crn != null ? 1 : 0 # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
   elasticsearch_key_name      = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_name}" : var.elasticsearch_key_name
   elasticsearch_key_ring_name = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_ring_name}" : var.elasticsearch_key_ring_name
 }
@@ -39,7 +39,7 @@ module "kms" {
   providers = {
     ibm = ibm.kms
   }
-  count                       = local.create_new_kms_key ? 1 : 0
+  count                       = local.create_new_kms_key
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
   version                     = "4.18.1"
   create_key_protect_instance = false

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -18,11 +18,11 @@ module "resource_group" {
 
 locals {
   # tflint-ignore: terraform_unused_declarations
-  validate_kms_1 = var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null || var.existing_kms_key_crn != null || var.existing_backup_kms_key_crn != null) ? tobool("When setting values for 'existing_kms_instance_crn', 'existing_kms_key_crn' or 'existing_backup_kms_key_crn', the 'use_ibm_owned_encryption_key' input must be set to false.") : true
+  validate_kms_1 = var.existing_db_instance_crn != null ? true : var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null || var.existing_kms_key_crn != null || var.existing_backup_kms_key_crn != null) ? tobool("When setting values for 'existing_kms_instance_crn', 'existing_kms_key_crn' or 'existing_backup_kms_key_crn', the 'use_ibm_owned_encryption_key' input must be set to false.") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_kms_2 = !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn == null && var.existing_kms_key_crn == null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value is required for either 'existing_kms_instance_crn' (to create a new key), or 'existing_kms_key_crn' to use an existing key.") : true
+  validate_kms_2 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn == null && var.existing_kms_key_crn == null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value is required for either 'existing_kms_instance_crn' (to create a new key), or 'existing_kms_key_crn' to use an existing key.") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_kms_3 = local.create_new_kms_key && var.existing_kms_instance_crn == null ? tobool("If a value is not provided for 'existing_db_instance_crn' or 'existing_kms_key_crn', and 'use_ibm_owned_encryption_key' is not set to true, you must provide a value for 'existing_kms_instance_crn'.") : true
+  validate_kms_3 = var.existing_db_instance_crn != null ? true : !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null && var.existing_kms_key_crn != null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value cannot be passed for both 'existing_kms_instance_crn' (to create a new key), and 'existing_kms_key_crn' to use an existing key.") : true
 }
 
 #######################################################################################################################
@@ -30,7 +30,7 @@ locals {
 #######################################################################################################################
 
 locals {
-  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null ? true : false # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
+  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null && var.existing_kms_instance_crn != null ? true : false # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
   elasticsearch_key_name      = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_name}" : var.elasticsearch_key_name
   elasticsearch_key_ring_name = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_ring_name}" : var.elasticsearch_key_ring_name
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -21,6 +21,8 @@ locals {
   validate_kms_1 = var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn != null || var.existing_kms_key_crn != null || var.existing_backup_kms_key_crn != null) ? tobool("When setting values for 'existing_kms_instance_crn', 'existing_kms_key_crn' or 'existing_backup_kms_key_crn', the 'use_ibm_owned_encryption_key' input must be set to false.") : true
   # tflint-ignore: terraform_unused_declarations
   validate_kms_2 = !var.use_ibm_owned_encryption_key && (var.existing_kms_instance_crn == null && var.existing_kms_key_crn == null) ? tobool("When 'use_ibm_owned_encryption_key' is false, a value is required for either 'existing_kms_instance_crn' (to create a new key), or 'existing_kms_key_crn' to use an existing key.") : true
+  # tflint-ignore: terraform_unused_declarations
+  validate_kms_3 = local.create_new_kms_key && var.existing_kms_instance_crn == null ? tobool("If a value is not provided for 'existing_db_instance_crn' or 'existing_kms_key_crn', and 'use_ibm_owned_encryption_key' is not set to true, you must provide a value for 'existing_kms_instance_crn'.") : true
 }
 
 #######################################################################################################################
@@ -28,7 +30,7 @@ locals {
 #######################################################################################################################
 
 locals {
-  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null ? 1 : 0 # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
+  create_new_kms_key          = var.existing_db_instance_crn == null && !var.use_ibm_owned_encryption_key && var.existing_kms_key_crn == null ? true : false # no need to create any KMS resources if using existing Elasticsearch, passing an existing key, or using IBM owned keys
   elasticsearch_key_name      = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_name}" : var.elasticsearch_key_name
   elasticsearch_key_ring_name = var.prefix != null ? "${var.prefix}-${var.elasticsearch_key_ring_name}" : var.elasticsearch_key_ring_name
 }
@@ -37,7 +39,7 @@ module "kms" {
   providers = {
     ibm = ibm.kms
   }
-  count                       = local.create_new_kms_key
+  count                       = local.create_new_kms_key ? 1 : 0
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
   version                     = "4.18.1"
   create_key_protect_instance = false


### PR DESCRIPTION
### Description

add extra validation for kms

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

add extra validation for kms when creating new kms key and existing kms instance is empty.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
