### PR TITLE
fix: main branch failure during PR tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-06-24T13:00:25Z",
+  "generated_at": "2025-07-01T08:59:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -110,7 +110,7 @@
         "hashed_secret": "8c7c51db5075ebd0369c51e9f14737d9b4c1c21d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 352,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -124,7 +124,7 @@ func TestRunSecurityEnforcedUpgradeSolution(t *testing.T) {
 		Testing:                    t,
 		TerraformDir:               securityEnforcedSolutionTerraformDir,
 		BestRegionYAMLPath:         regionSelectionPath,
-		Prefix:                     "els-st-da-upg",
+		Prefix:                     "es-da-upg",
 		ResourceGroup:              resourceGroup,
 		CheckApplyResultForUpgrade: true,
 	})
@@ -184,7 +184,6 @@ func TestRunSecurityEnforcedSolutionSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "kms_encryption_enabled", Value: true, DataType: "bool"},
 		{Name: "access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "existing_kms_instance_crn", Value: permanentResources["hpcs_south_crn"], DataType: "string"},
 		{Name: "existing_resource_group_name", Value: resourceGroup, DataType: "string"},


### PR DESCRIPTION
### Description

Fixes for recent test failure during renovate PR pipelines

1. Upgrade test name too long
2. Security enforced test does not take flags to enable to security

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
