### PR TITLE
fix: temporarily disabling index creation

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -38,21 +38,24 @@ module "database" {
 
 # wait 60 secs to allow IAM credential access to kick in before configuring instance
 # without the wait, you can intermittently get "Error 401 (Unauthorized)"
-resource "time_sleep" "wait" {
-  depends_on      = [module.database]
-  create_duration = "60s"
-}
 
-resource "elasticsearch_index" "test" {
-  depends_on         = [time_sleep.wait]
-  name               = "terraform-test"
-  number_of_shards   = 1
-  number_of_replicas = 1
-  force_destroy      = true
-}
+# Temporarily disabling index creation due to an know issue blocking the pipeline : https://github.ibm.com/GoldenEye/issues/issues/16245.
 
-resource "elasticsearch_cluster_settings" "global" {
-  depends_on                  = [time_sleep.wait]
-  cluster_max_shards_per_node = 10
-  action_auto_create_index    = "my-index-000001,index10,-index1*,+ind*"
-}
+# resource "time_sleep" "wait" {
+#   depends_on      = [module.database]
+#   create_duration = "60s"
+# }
+
+# resource "elasticsearch_index" "test" {
+#   depends_on         = [time_sleep.wait]
+#   name               = "terraform-test"
+#   number_of_shards   = 1
+#   number_of_replicas = 1
+#   force_destroy      = true
+# }
+
+# resource "elasticsearch_cluster_settings" "global" {
+#   depends_on                  = [time_sleep.wait]
+#   cluster_max_shards_per_node = 10
+#   action_auto_create_index    = "my-index-000001,index10,-index1*,+ind*"
+# }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -12,9 +12,9 @@ terraform {
       version = ">= 2.0.7"
     }
     # The time provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9.1"
-    }
+    # time = {
+    #   source  = "hashicorp/time"
+    #   version = ">= 0.9.1"
+    # }
   }
 }


### PR DESCRIPTION
### Description

disables index creation in basic example

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This PR temporarily disabling index creation in basic example due to an issue with connecting to the instance while index creation

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
