### PR TITLE
feat: add automated Elasticsearch version check workflow

### DIFF
--- a/.github/workflows/check-elasticsearch-versions.yml
+++ b/.github/workflows/check-elasticsearch-versions.yml
@@ -1,0 +1,40 @@
+# ============================================================================
+# Elasticsearch Version Check Workflow
+# ============================================================================
+# Checks for Elasticsearch version changes in IBM Cloud Databases and creates
+# PRs to update supported versions in this module.
+#
+# Runs daily at 6 AM UTC and can be triggered manually.
+# No manual version maintenance required - versions are extracted from the
+# codebase automatically.
+# ============================================================================
+
+name: Check Elasticsearch Versions
+
+on:
+  # TODO: Remove after testing
+  push:
+    branches:
+      - feat/auto-version-check
+
+  schedule:
+    # Run daily at 6:00 AM UTC
+    - cron: '0 6 * * *'
+
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not create PRs)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  check-versions:
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/icd-version-update.yml@feat/icd-version-automation
+    with:
+      icd_service_type: 'elasticsearch'
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically checks for Elasticsearch version updates from IBM Cloud Databases and creates PRs when changes are detected.

## How It Works

- Runs daily at 6 AM UTC (configurable)
- Fetches available Elasticsearch versions from IBM Cloud API
- Extracts current versions from `variables.tf` (no manual maintenance needed)
- Creates a PR if new versions are available or old versions are deprecated
- Updates:
  - `variables.tf` - validation block
  - `ibm_catalog.json` - version options
  - `tests/pr_test.go` - latestVersion constant

## Dependencies

This workflow uses a reusable workflow from common-pipeline-assets:
- PR: https://github.com/terraform-ibm-modules/common-pipeline-assets/pull/830

## Testing

1. Merge the common-pipeline-assets PR first (or test with the feature branch reference)
2. Run the workflow manually with "dry run" enabled to verify detection works
3. Once validated, update the workflow to reference `@main`

## Required Secrets

- `IBMCLOUD_API_KEY` - IBM Cloud API key with access to Cloud Databases service